### PR TITLE
Implement GitImage with Config

### DIFF
--- a/system/Cargo.lock
+++ b/system/Cargo.lock
@@ -236,6 +236,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,6 +592,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.6.0",
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,6 +722,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -750,6 +787,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -1027,6 +1075,7 @@ name = "system"
 version = "0.1.0-dev"
 dependencies = [
  "clap",
+ "dirs",
  "reqwest",
  "serde",
  "serde_json",
@@ -1065,6 +1114,26 @@ dependencies = [
  "fastrand",
  "rustix",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/system/Cargo.toml
+++ b/system/Cargo.toml
@@ -10,3 +10,4 @@ sha2 = "0.10.8"
 clap = { version = "4.5.9", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+dirs = "5.0.1"

--- a/system/image/git.config.json
+++ b/system/image/git.config.json
@@ -1,0 +1,14 @@
+{
+  "core": {
+    "excludes_file": ""
+  },
+  "user": {
+    "name": "",
+    "email": "",
+    "signing_key": ""
+  },
+  "commit": {
+    "gpg_sign": false
+  },
+  "git_ignore": []
+}

--- a/system/src/image/repository.rs
+++ b/system/src/image/repository.rs
@@ -118,6 +118,8 @@ impl LoadImage for RepositoryImageLoader<ServerImageId> {
                 .load_concrete(MinicondaImage::new)
                 .and_then(|image| ctx.load_to_image_config(image))?,
 
+            Git => ctx.load_to_image_config(GitImage::new(os))?,
+
             _ => Err(OperationNotImplemented(
                 self.id.to_image_id(),
                 "config".to_string(),

--- a/system/src/image/repository.rs
+++ b/system/src/image/repository.rs
@@ -6,7 +6,7 @@ use std::fmt::{Display, Formatter};
 use std::path::PathBuf;
 use DesktopImageId::{CLion, DataGrip, Goland, IntelliJIdea, JetBrainsToolbox, PhpStorm, PyCharm, Rider, RubyMine, RustRover, VsCode, WebStorm};
 use ImageOperationError::OperationNotImplemented;
-use ServerImageId::{Go, Gradle, Java, Miniconda, Node, Nvm, Rust, Sdkman};
+use ServerImageId::{Git, Go, Gradle, Java, Miniconda, Node, Nvm, Rust, Sdkman};
 
 use crate::image::desktop::jetbrains_ide::JetBrainsIdeImage;
 use crate::image::desktop::jetbrains_toolbox::JetBrainsToolboxImage;
@@ -24,6 +24,7 @@ use crate::image::server::rust::RustImage;
 use crate::image::server::sdkman::SdkmanImage;
 use crate::image::server::ServerImageId;
 use crate::image::{Config, ImageId, ImageInfoError, ImageInfoLoader, ImageLoadContext, ImageLoader, ImageOperationError, ImageOps, LoadImage, StrFind, ToImageId};
+use crate::image::server::git::GitImage;
 use crate::os::Os;
 
 struct RepositoryImageLoader<T> where T: Display + ToImageId {
@@ -100,7 +101,8 @@ impl LoadImage for RepositoryImageLoader<ServerImageId> {
             Gradle => ctx.load(GradleImage::new)?,
             Nvm => ctx.load(NvmImage::new)?,
             Node => ctx.load(NodeImage::new)?,
-            Miniconda => ctx.load(MinicondaImage::new)?
+            Miniconda => ctx.load(MinicondaImage::new)?,
+            Git => ImageLoadContext::basic_image_from(os, GitImage::new),
         };
 
         Ok(image)

--- a/system/src/image/server.rs
+++ b/system/src/image/server.rs
@@ -1013,17 +1013,20 @@ pub mod miniconda {
 }
 
 pub mod git {
-    use reqwest::Url;
-
-    use crate::cmd::{exec_cmd, print_output};
+    use crate::cmd::{exec_cmd, exec_cmd_async, print_output};
     use crate::image::server::ServerImage;
     use crate::image::server::ServerImageId::Git;
-    use crate::image::Image;
+    use crate::image::{Config, Image, ImageConfig, ToImageConfig};
     use crate::image::{ImageOps, Install, Uninstall};
-    use crate::image_ops_impl;
     use crate::os::Os;
     use crate::package::{Package, Software};
+    use crate::{image_ops_impl, os};
+    use reqwest::Url;
+    use serde::{Deserialize, Serialize};
+    use std::fs;
+    use std::process::Output;
 
+    #[derive(Clone)]
     pub struct GitImage(ServerImage);
 
     impl GitImage {
@@ -1065,7 +1068,7 @@ pub mod git {
 
             let output = exec_cmd(
                 "sudo",
-                &["apt-get", "--yes", "remove", "git"]
+                &["apt-get", "--yes", "remove", "git"],
             ).map_err(|error| error.to_string())?;
 
             print_output(output);
@@ -1077,4 +1080,149 @@ pub mod git {
     }
 
     impl ImageOps for GitImage { image_ops_impl!(); }
+
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    pub struct Core {
+        excludes_file: String,
+    }
+
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    pub struct User {
+        name: String,
+        email: String,
+        signing_key: String,
+    }
+
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    pub struct Commit {
+        gpg_sign: bool,
+    }
+
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    pub struct GitConfig {
+        core: Core,
+        user: User,
+        commit: Commit,
+        git_ignore: Vec<String>,
+    }
+
+    type GitImageConfig = ImageConfig<GitImage, GitConfig>;
+
+    impl ToImageConfig<GitConfig> for GitImage {
+        fn to_image_config(&self, config: GitConfig) -> GitImageConfig {
+            ImageConfig(self.clone(), config)
+        }
+    }
+
+    impl Config for GitImageConfig {
+        fn config(&self) -> Result<(), String> {
+            let GitConfig { core, user, commit, git_ignore } = self.1.clone();
+
+            println!("Configuring Git Core...");
+
+            let output = exec_git_config_global(
+                "core.excludesFile",
+                &core.excludes_file,
+            )?;
+
+            print_output(output);
+
+            println!("Copying Git ignore...");
+
+            let new_line = |acc, cur| format!("{acc}\n{cur}");
+            let git_ignore_contents = git_ignore
+                .iter()
+                .fold("".to_string(), new_line);
+
+            write_git_ignore_file(core.excludes_file, git_ignore_contents)?;
+
+            println!("Configuring Git User...");
+
+            let output = exec_git_config_global(
+                "user.name",
+                &user.name,
+            )?;
+
+            print_output(output);
+
+            let output = exec_git_config_global(
+                "user.email",
+                &user.email,
+            )?;
+
+            print_output(output);
+
+            println!("Configuring GPG...");
+
+            let output = exec_git_config_global_unset("gpg.format")?;
+
+            print_output(output);
+
+            let output = exec_git_config_global(
+                "user.signingkey",
+                &user.signing_key,
+            )?;
+
+            print_output(output);
+
+            let output = exec_git_config_global(
+                "commit.gpgsign",
+                &commit.gpg_sign.to_string(),
+            )?;
+
+            print_output(output);
+
+            Ok(())
+        }
+    }
+
+    fn exec_git_config_global(
+        arg1: &str,
+        arg2: &str,
+    ) -> Result<Output, String> {
+        exec_cmd("git", &["config", "--global", arg1, arg2])
+            .map_err(|error| error.to_string())
+    }
+
+    /// The unset flag returns status code 5 if it was not necessary to do
+    /// anything (the value was not present, so there's nothing to unset).
+    fn exec_git_config_global_unset(
+        prop: &str,
+    ) -> Result<Output, String> {
+        let args = ["config", "--global", "--unset", prop];
+        let output = exec_cmd_async("git", &args)
+            .map_err(|error| error.to_string())?
+            .wait_with_output()
+            .map_err(|error| error.to_string())?;
+
+        match output.status.code() {
+            Some(0) | Some(5) => Ok(output),
+            Some(n) => Err(format!("Unsuccessful code {n}.")),
+            None => Err("Unable to get status code.".to_string())
+        }
+    }
+
+    fn write_git_ignore_file(
+        excludes_file: String,
+        git_ignore_contents: String,
+    ) -> Result<(), String> {
+        if excludes_file.trim().is_empty() {
+            return match git_ignore_contents.is_empty() {
+                true => Ok(()),
+                false => Err("Value 'excludes_file' is empty but the \
+                Git ignore list is not. Provide a valid `excludes_file` value \
+                to copy the given Git ignore values.".to_string())
+            };
+        }
+
+        let git_ignore_path
+            = os::linux::expand_home_path(&excludes_file);
+
+        fs::write(git_ignore_path.clone(), git_ignore_contents)
+            .map_err(|error| format!(
+                "Fail to write Git ignore {}: {}",
+                git_ignore_path,
+                error,
+            ))
+    }
 }


### PR DESCRIPTION
It adds the `GitImage` to the repository and the tooling necessary to implement its `Config` operation.

The config file is an empty structure at `image/git.config.json` you replace with your values.

- It includes configuration fields for Git `Core`, `User`, and `Commit`.
- It allows you to set and enforce sign commits with GPG.
- It allows you to set the global Git ignore file that applies to all Git repositories on your machine.

You can run `system install git`, `system install --config git`, `system config git`, etc.

The Git implementation is quite useful for setting up a workstation machine from cold-start with your personal Git environment.